### PR TITLE
Haml用gemインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,5 @@ group :development do
   gem 'spring'
 end
 
+gem 'haml-rails'
+gem 'erb2haml'


### PR DESCRIPTION
# WHAT

Haml用gemのインストール
# WHY

Hamlを使用することで綺麗に、読みやすく、生産的にビューを作成するため
